### PR TITLE
Docker image for Balena OS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,0 +1,43 @@
+ARG NODEJS_VERSION="20"
+
+# If we specify BALENA_MACHINE_NAME, when we do a 'balena push', it will automatically substitute the machine type into our variable, so that you can build it for more than one architecture.
+FROM balenalib/%%BALENA_MACHINE_NAME%%-node:${NODEJS_VERSION}-run
+
+RUN install_packages \
+    curl \
+    libasound2 \
+    libdrm2 \
+    libgbm1 \
+    libgdk-pixbuf2.0-0 \
+    libglib2.0-0 \
+    libgtk-3-0 \
+    libnss3 \
+    libx11-xcb1 \
+    libxss1 \
+    libxtst6 \
+    libgles2-mesa \
+    libxshmfence1 \
+    mesa-utils \
+    mesa-utils-extra
+
+WORKDIR /opt
+
+# Copy package files
+COPY package.json package-lock.json /opt/
+
+# Install node dependencies
+RUN JOBS=MAX npm install --unsafe-perm --production && npm cache clean --force && rm -rf /root/.cache/*
+
+# Now that we are done NPM installing, copy everything else
+COPY chrome /opt/chrome
+COPY config /opt/config
+COPY main.js start.sh /opt/
+
+# We are running our entrypoint commands through the start.sh script, because we need to do a couple more things outside of just run electron
+CMD ["bash", "/opt/start.sh"]
+
+ENV NODE_ENV=production \
+    # this is specific for balena, to let the startup script know we want to use all udev devices (mouse, keyboard, etc)
+    UDEV=1 \
+    # this is very important, we need to tell our environment that we are going to talk to display 0, which is hosted by the xserver block
+    DISPLAY=:0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '2.1'
+volumes:
+    # we create a shared volume so that the xserver can mount its socket file, and our application container will be able to use it to display
+    xserver-volume:
+services:
+  xserver:
+    image: webthingsio/xserver
+    restart: always
+    privileged: true
+    volumes:
+      # when we start, a UNIX socket is mounted in this directory, for communication to the X server
+      - 'xserver-volume:/tmp/.X11-unix'
+  webthings-shell:
+    build: .
+    restart: always
+    network_mode: host
+    volumes:
+      # We will have access to the UNIX socket shared by xserver after it has started up.
+      - 'xserver-volume:/tmp/.X11-unix'
+    environment:
+      # We need to specify which display we want to use for the X server. :0 is the first display that we have plugged in. This because there is no default display specified.
+      - DISPLAY=:0

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   "author": "WebThingsIO",
   "license": "MPL-2.0",
   "devDependencies": {
-    "electron": "^35.1.5",
     "electron-packager": "^17.1.1"
   },
   "dependencies": {
+    "electron": "^35.1.5",
     "url-regex": "^5.0.0",
     "uuid": "^11.1.0"
   }

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# We are going to wait for the UNIX socket to be mounted before trying to start the application. This will prevent us from going into a crash loop before xserver is ready. See more info here: https://github.com/balenablocks/xserver#waiting-for-xserver-to-start
+while [ ! -e /tmp/.X11-unix/X${DISPLAY#*:} ]; do sleep 0.5; done
+
+# Run balena base image entrypoint script. We also specified UDEV=1 in the Dockerfile. This will allow udev devices (mouse, etc) to be mounted
+/usr/bin/entry.sh echo "Running balena base image entrypoint..."
+
+# This stops the CPU performance scaling down
+echo "Setting CPU Scaling Governor to 'performance'"
+echo 'performance' > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor 
+
+# We are using root to run --no-sandbox for chrome, partially because of this issue: https://github.com/electron/electron/issues/17972
+/opt/node_modules/.bin/electron --no-sandbox /opt/main.js


### PR DESCRIPTION
This PR adds a Dockerfile and docker-compose.yml to get WebThings Shell, with the goal of running it on [balenaOS](https://www.balena.io/os).

Note that this uses a [WebThings fork of the xserver block](https://github.com/WebThingsIO/xserver) for running X11 inside a Docker container.

The image works on balenaOS, but currently there is no on-screen keyboard.